### PR TITLE
ws2812 timings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,19 @@
 //! If it's too slow (e.g.  e.g. all/some leds are white or display the wrong color)
 //! you may want to try the `slow` feature.
 
+// https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/
+//                                          Min     Typ     Max     Units
+// T0H      0 code  high voltage time       200     350     500     ns
+// T1H      1 code  high voltage time       550     700     5,500   ns
+// TLD      data    low voltage time        450     600     5,000   ns
+// TLL      latch   low voltage time        6,000                   ns
+
+// The tricky timing is the T0H between 200 and 350ns timing.
+// 3mhz is 333ns per block and should be flexible for all other timings
+
+// But new device reset latch timing is posted as 280us
+// https://blog.particle.io/2017/05/11/heads-up-ws2812b-neopixels-are-about-to-change/
+
 #![no_std]
 
 use embedded_hal as hal;
@@ -61,16 +74,18 @@ where
     fn write_byte(&mut self, mut data: u8) {
         for _ in 0..8 {
             if (data & 0x80) != 0 {
-                block!(self.timer.wait()).ok();
+                // 1bit, 666ns on time, 666ns off time
                 self.pin.set_high().ok();
                 block!(self.timer.wait()).ok();
                 block!(self.timer.wait()).ok();
                 self.pin.set_low().ok();
+                block!(self.timer.wait()).ok();
             } else {
-                block!(self.timer.wait()).ok();
+                // 0bit, 333ns on time, 666ns off time
                 self.pin.set_high().ok();
                 block!(self.timer.wait()).ok();
                 self.pin.set_low().ok();
+                block!(self.timer.wait()).ok();
                 block!(self.timer.wait()).ok();
             }
             data <<= 1;
@@ -97,9 +112,11 @@ where
             self.write_byte(item.r);
             self.write_byte(item.b);
         }
-        // Get a timeout period of 300 ns
+
+        // Latch for > 280 us
+        // 900 * 333 = 299 us
         for _ in 0..900 {
-            block!(self.timer.wait()).ok();
+            let _ = block!(self.timer.wait());
         }
         Ok(())
     }


### PR DESCRIPTION
Greetings all. Thanks for all the great libraries. 

In attempting to figure out why my atasmd pygamer examples with a perfectly good timer needed to push clock from 3mhz up to 3.1-3.8mhz, and then higher when I removed this seemingly pointless extra for loop that seems it be in most exmaples 
https://github.com/atsamd-rs/atsamd/blob/master/boards/pygamer/examples/neopixel_rainbow_timer.rs#L53

I took a look at the original timings and compared from
https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/

I believe the current timings are shorting the low part of the 0 and 1 bit. Ive pushed this up by 333ns (1 block) to 666ns for both and Im seeing vastly better results and at 3mhz even, no extra loops, lto etc fudging.

Secondly, the latch timing is much larger than it needs to be, I brought that down to its minimum ~6000ns.

I havent touched the slow path, because I dont understand what numbers thats trying to hit, but I think that needs a look to. Also I realize people tend to try to use these same code paths for other chips where we might want to stretch numbers here to accommodate. However, it would be best if those assumptions were documented.

~~Note this makes all the 'wheel' examples in atsamd not look as pretty, but I think thats because they were built to accommodate the old timings
https://github.com/atsamd-rs/atsamd/blob/master/boards/pygamer/examples/neopixel_rainbow_timer.rs#L55~~

This code transitions colors very nicely so I know its not the drive
```
    loop {
        for j in 0..=255u8 {
            let colors: [RGB8; NUM_LEDS] = [
                wheel(j).into(),
                wheel(j).into(),
                wheel(j).into(),
                wheel(j).into(),
                wheel(j).into(),
            ];

            let _ = neopixel.write(brightness(colors.iter().cloned(), 32));
            delay.delay_ms(5u8);
        }
    }

```
