### PR TITLE
Don't use &mut for the gpio

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,18 +19,18 @@ use smart_leds_trait::{SmartLedsWrite, RGB8};
 use nb;
 use nb::block;
 
-pub struct Ws2812<'a, TIMER, PIN> {
+pub struct Ws2812<TIMER, PIN> {
     timer: TIMER,
-    pin: &'a mut PIN,
+    pin: PIN,
 }
 
-impl<'a, TIMER, PIN> Ws2812<'a, TIMER, PIN>
+impl<TIMER, PIN> Ws2812<TIMER, PIN>
 where
     TIMER: CountDown + Periodic,
     PIN: OutputPin,
 {
     /// The timer has to already run at with a frequency of 3 MHz
-    pub fn new(timer: TIMER, pin: &'a mut PIN) -> Ws2812<'a, TIMER, PIN> {
+    pub fn new(timer: TIMER, mut pin: PIN) -> Ws2812<TIMER, PIN> {
         pin.set_low().ok();
         Self { timer, pin }
     }
@@ -78,7 +78,7 @@ where
     }
 }
 
-impl<TIMER, PIN> SmartLedsWrite for Ws2812<'_, TIMER, PIN>
+impl<TIMER, PIN> SmartLedsWrite for Ws2812<TIMER, PIN>
 where
     TIMER: CountDown + Periodic,
     PIN: OutputPin,


### PR DESCRIPTION
Doesn't make much sense to only own one of the peripherals.
It may be useful for some gpio expanders, but they're too slow anyways

I've tried using BorrowMut [here](https://github.com/david-sawatzke/ws2812-timer-delay-rs/blob/e63ee48038c908f33d143cfd2480368558dcfd7b/src/lib.rs#L32), so you can use both styles, but it's a bit hacky and i don't like it. The compiler also quickly fails to interfere the `INNER_*` types.

@sajattack Any thoughts? Ideas?